### PR TITLE
fix anchor rotations in mktunnel

### DIFF
--- a/mcwb/api.py
+++ b/mcwb/api.py
@@ -4,7 +4,7 @@ from mcipc.rcon.client import Client
 from mcipc.rcon.enumerations import FillMode, Item
 
 from mcwb.functions import check_xz_dir
-from mcwb.functions import get_offset
+from mcwb.functions import offsets
 from mcwb.functions import normalize
 from mcwb.functions import validate
 from mcwb.types import Anchor, Direction, Profile, Vec3
@@ -29,13 +29,10 @@ def mktunnel(client: Client, profile: Profile, start: Vec3, *,
     else:
         end = Vec3(*end)    # Ensure Vec3 object.
 
-    direction = check_xz_dir(start, end)
+    calculated_direction = check_xz_dir(start, end)
     profile = list(normalize(profile, default=default))
 
-    for y, row in enumerate(profile):   # pylint: disable=C0103
-        for xz, block in enumerate(row):    # pylint: disable=C0103
-            offset = get_offset(y, xz, direction, anchor)
-            result = client.fill(
-                start + offset, end + offset, block, mode=mode, filter=filter
-            )
-            print(result)
+    for block, offset in offsets(profile, calculated_direction, anchor):
+        client.fill(
+            start + offset, end + offset, block, mode=mode, filter=filter
+        )

--- a/mcwb/functions.py
+++ b/mcwb/functions.py
@@ -40,28 +40,30 @@ def check_xz_dir(start: Vec3, end: Vec3) -> Vec3:
 
 
 # pylint: disable=C0103
-def get_offset(y: int, xz: int, direction: Vec3, anchor: Anchor) -> Vec3:
-    """Returns returns the offset."""
+def offsets(profile: Profile, direction: Vec3, anchor: Anchor):
+    height = len(profile)
+    width = len(profile[0])
 
-    top = anchor in {Anchor.TOP_LEFT, Anchor.TOP_RIGHT}
-    left = anchor in {Anchor.TOP_LEFT, Anchor.BOTTOM_LEFT}
+    y_start = x_start = 0
+    if anchor in {Anchor.BOTTOM_LEFT, Anchor.BOTTOM_RIGHT}:
+        y_start = height - 1
+    if anchor in {Anchor.TOP_RIGHT, Anchor.BOTTOM_RIGHT}:
+        x_start = width - 1
 
-    if direction.north:
-        return Vec3(xz if left else -xz, -y if top else y, 0)
-
-    if direction.south:
-        return Vec3(-xz if left else xz, -y if top else y, 0)
-
-    if direction.east:
-        return Vec3(0, -y if top else y, xz if left else -xz)
-
-    if direction.west:
-        return Vec3(0, -y if top else y, -xz if left else xz)
-
-    if direction.up:
-        return Vec3(xz if left else -xz, 0, -y if top else y)
-
-    if direction.down:
-        return Vec3(xz if left else -xz, 0, y if top else -y)
-
-    raise ValueError('Cannot determine offset.')
+    for y, row in enumerate(profile):  # pylint: disable=C0103
+        for xz, block in enumerate(row):  # pylint: disable=C0103
+            if direction.north:
+                v = Vec3(-x_start + xz, y_start - y, 0)
+            elif direction.south:
+                v = Vec3(x_start - xz, y_start - y, 0)
+            elif direction.east:
+                v = Vec3(0, y_start - y, -x_start + xz)
+            elif direction.west:
+                v = Vec3(0, y_start - y, x_start - xz)
+            elif direction.up:
+                v = Vec3(-x_start + xz, 0, y_start - y)
+            elif direction.down:
+                v = Vec3(-x_start + xz, 0, -y_start + y)
+            else:
+                raise ValueError("Cannot determine offset.")
+            yield block, v


### PR DESCRIPTION
fixes an issue where anchors other than BOTOM_LEFT cause a rotation of the profile around the anchor point.

To prove this works as expected the function test_anchor below:
```
from mcipc.rcon.enumerations import FillMode, Item
from mcwb import Vec3, Direction, mktunnel, Profile, Anchor
from mcipc.rcon.je import Client


def knot(client: Client, mid: Vec3, a: Anchor):
    p: Profile = [
        [Item.RED_CONCRETE, Item.AIR, Item.GREEN_CONCRETE],
        [Item.AIR, Item.AIR, Item.AIR],
        [Item.BLUE_CONCRETE, Item.AIR, Item.YELLOW_CONCRETE],
    ]
    f = FillMode.KEEP
    mktunnel(client, p, mid, direction=Direction.NORTH, length=5, mode=f, anchor=a)
    mktunnel(client, p, mid, direction=Direction.SOUTH, length=5, mode=f, anchor=a)
    mktunnel(client, p, mid, direction=Direction.EAST, length=5, mode=f, anchor=a)
    mktunnel(client, p, mid, direction=Direction.WEST, length=5, mode=f, anchor=a)
    mktunnel(client, p, mid, direction=Direction.UP, length=5, mode=f, anchor=a)
    mktunnel(client, p, mid, direction=Direction.DOWN, length=5, mode=f, anchor=a)


def test_anchor(client, location):
    mid = location
    knot(client, mid, Anchor.TOP_LEFT)  # all should join at RED
    mid += Direction.EAST.value * 10
    knot(client, mid, Anchor.TOP_RIGHT)  # all shouls join at GREEN
    mid += Direction.EAST.value * 10
    knot(client, mid, Anchor.BOTTOM_LEFT)  # joins at BLUE
    mid += Direction.EAST.value * 10
    knot(client, mid, Anchor.BOTTOM_RIGHT)  # joins at YELLOW
    # mid += Direction.EAST.value * 10
    # knot(client, mid, Anchor.MIDDLE)  # joins in center
```

generates these objects:
![image](https://user-images.githubusercontent.com/964827/103820538-73854e80-5064-11eb-8a08-3edd73fec5cc.png)
