### PR TITLE
add centre anchor

### DIFF
--- a/mcwb/functions.py
+++ b/mcwb/functions.py
@@ -49,7 +49,7 @@ def offsets(profile: Profile, direction: Vec3, anchor: Anchor):
         y_start = height - 1
     if anchor in {Anchor.TOP_RIGHT, Anchor.BOTTOM_RIGHT}:
         x_start = width - 1
-    elif anchor == Anchor.CENTRE:
+    elif anchor == Anchor.MIDDLE:
         x_start = int(width / 2)
         y_start = int(height / 2)
 

--- a/mcwb/functions.py
+++ b/mcwb/functions.py
@@ -49,6 +49,9 @@ def offsets(profile: Profile, direction: Vec3, anchor: Anchor):
         y_start = height - 1
     if anchor in {Anchor.TOP_RIGHT, Anchor.BOTTOM_RIGHT}:
         x_start = width - 1
+    elif anchor == Anchor.CENTRE:
+        x_start = int(width / 2)
+        y_start = int(height / 2)
 
     for y, row in enumerate(profile):  # pylint: disable=C0103
         for xz, block in enumerate(row):  # pylint: disable=C0103

--- a/mcwb/types.py
+++ b/mcwb/types.py
@@ -17,6 +17,7 @@ class Anchor(Enum):
     TOP_RIGHT = 'top_right'
     BOTTOM_LEFT = 'bottom_left'
     BOTTOM_RIGHT = 'bottom_right'
+    CENTRE = 'centre'
 
 
 class Vec3(NamedTuple):

--- a/mcwb/types.py
+++ b/mcwb/types.py
@@ -17,7 +17,7 @@ class Anchor(Enum):
     TOP_RIGHT = 'top_right'
     BOTTOM_LEFT = 'bottom_left'
     BOTTOM_RIGHT = 'bottom_right'
-    CENTRE = 'centre'
+    MIDDLE = 'middle'
 
 
 class Vec3(NamedTuple):


### PR DESCRIPTION
add a centre anchor for mktunnel so that this code:
```
def knot(client: Client, mid: Vec3, a: Anchor):
    p: Profile = [
        [Item.RED_CONCRETE, Item.AIR, Item.GREEN_CONCRETE],
        [Item.AIR, Item.AIR, Item.AIR],
        [Item.BLUE_CONCRETE, Item.AIR, Item.YELLOW_CONCRETE],
    ]
    f = FillMode.KEEP
    mktunnel(client, p, mid, direction=Direction.NORTH, length=5, mode=f, anchor=a)
    mktunnel(client, p, mid, direction=Direction.SOUTH, length=5, mode=f, anchor=a)
    mktunnel(client, p, mid, direction=Direction.EAST, length=5, mode=f, anchor=a)
    mktunnel(client, p, mid, direction=Direction.WEST, length=5, mode=f, anchor=a)
    mktunnel(client, p, mid, direction=Direction.UP, length=5, mode=f, anchor=a)
    mktunnel(client, p, mid, direction=Direction.DOWN, length=5, mode=f, anchor=a)


def test_anchor(client: Client, mid: Vec3):
    mid += Direction.EAST.value * 10
    knot(client, mid, Anchor.CENTRE)  # join in center
```

generates this object:
![image](https://user-images.githubusercontent.com/964827/103876855-16bd7e80-50cc-11eb-9871-b9483d4e200e.png)
