### PR TITLE
fix type of profile in volume.fill()

### DIFF
--- a/mcwb/volume.py
+++ b/mcwb/volume.py
@@ -101,7 +101,7 @@ class Volume:
         if self.size.volume < MAX_MINECRAFT_FILL_COMMAND:
             client.fill(self.start, self.end, block.value)
         else:
-            profile = [[block.value] * int(self.size.x)] * int(self.size.y)
+            profile = [[block] * int(self.size.x)] * int(self.size.y)
             mktunnel(
                 client,
                 profile,


### PR DESCRIPTION
The Volume.fill() function was failing for large volumes because it is passing list(list(str)) to mktunnel.

Then mktunnel's call to validate fails because validate verifies that the type of array is Item.

We could loosen validate to also accept type string but that is not really correct as the sting 'bogus block' is not valid, plus I intend to extend Item to include block states in future.

This issue was missed because I don't have any tests for functions that call mcwc at present. How are you testing mcwc? Here I could mock out the mcwc calls or spin up a java minecraft server and have some system tests.